### PR TITLE
Fix checkpoint path with env var

### DIFF
--- a/sslmodel.py
+++ b/sslmodel.py
@@ -5,6 +5,10 @@ import torch.nn as nn
 import numpy as np
 import random
 from pathlib import Path
+import os
+
+# Base directory for data and model outputs
+BASE_DIR = os.getenv('OUTPUT_DIR', '/content/drive/MyDrive/hd_data/model_outputs')
 from transforms3d.axangles import axangle2mat
 from tqdm import tqdm
 from torchvision import transforms
@@ -133,7 +137,7 @@ class EarlyStopping:
             patience=15,
             verbose=False,
             delta=0,
-            path="/mlwell-data2/dafna/ssl_gait_detection/model_outputs/checkpoints/checkpoint.pt",#"checkpoint.pt",
+            path=os.path.join(os.getenv('OUTPUT_DIR', BASE_DIR + '/model_outputs'), 'checkpoints', 'checkpoint.pt'),
             trace_func=print,
     ):
         """


### PR DESCRIPTION
## Summary
- update `sslmodel.py` to load `os` and set `BASE_DIR`
- make EarlyStopping checkpoint path configurable via OUTPUT_DIR

## Testing
- `python -m py_compile sslmodel.py`

------
https://chatgpt.com/codex/tasks/task_e_684f2f81c9008327809aa5cfe130dc60